### PR TITLE
Avoid throwing .NET Exceptions back to Dokan driver

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -179,12 +179,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("CreateFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -207,12 +203,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("OpenDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.Error;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -235,12 +227,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("CreateDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.Error;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -263,12 +251,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("CleanupProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -291,12 +275,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("CloseFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -323,12 +303,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("ReadFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -356,12 +332,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("WriteFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -384,12 +356,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -447,12 +415,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("GetFileInformationProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -503,12 +467,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("FindFilesProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.InvalidHandle;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -565,12 +525,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("SetEndOfFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -592,12 +548,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -621,12 +573,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("SetFileAttributesProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -663,12 +611,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("SetFileTimeProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -691,12 +635,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("DeleteFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -719,12 +659,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -751,12 +687,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("MoveFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -782,12 +714,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("LockFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -813,12 +741,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("UnlockFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -846,12 +770,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("GetDiskFreeSpaceProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -891,12 +811,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("GetVolumeInformationProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -916,12 +832,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("UnmountProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -980,12 +892,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("GetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -1035,12 +943,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("SetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -1070,12 +974,8 @@ namespace DokanNet
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
                 DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                return (int)DokanResult.ExceptionInService;
             }
         }
 

--- a/sample/DokanNetMirror/DokanNetMirror.csproj
+++ b/sample/DokanNetMirror/DokanNetMirror.csproj
@@ -41,6 +41,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -50,6 +51,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -92,7 +94,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DokanNet\DokanNet.csproj">

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -1,19 +1,17 @@
 ﻿using DokanNet;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
-using System.Threading;
 using FileAccess = DokanNet.FileAccess;
 
 namespace DokanNetMirror
 {
     internal class Mirror : IDokanOperations
     {
-        private readonly string _path;
+        private readonly string path;
 
         private const FileAccess DataAccess = FileAccess.ReadData | FileAccess.WriteData | FileAccess.AppendData |
                                               FileAccess.Execute |
@@ -23,41 +21,51 @@ namespace DokanNetMirror
                                                    FileAccess.Delete |
                                                    FileAccess.GenericWrite;
 
-        private int streamCount;
-
-        private IDictionary<Stream, int> streamIds = new ConcurrentDictionary<Stream, int>();
-
         public Mirror(string path)
         {
             if (!Directory.Exists(path))
                 throw new ArgumentException("path");
-            _path = path;
+            this.path = path;
         }
 
         private string GetPath(string fileName)
         {
-            return _path + fileName;
+            return path + fileName;
         }
 
         private string ToTrace(DokanFileInfo info)
         {
-            var contextStream = info.Context as FileStream;
-            string context = contextStream != null ? streamIds[contextStream].ToString() : "<null>";
-            return $"{{{context}, {info.DeleteOnClose}, {info.IsDirectory}, {info.NoCache}, {info.PagingIo}, #{info.ProcessId}, {info.SynchronousIo}, {info.WriteToEndOfFile}}}";
+            var context = info.Context != null ? "<" + info.Context.GetType().Name + ">" : "<null>";
+
+            return string.Format(CultureInfo.InvariantCulture, "{{{0}, {1}, {2}, {3}, {4}, #{5}, {6}, {7}}}",
+                context, info.DeleteOnClose, info.IsDirectory, info.NoCache, info.PagingIo, info.ProcessId, info.SynchronousIo, info.WriteToEndOfFile);
+        }
+
+        private string ToTrace(DateTime? date)
+        {
+            return date.HasValue ? date.Value.ToString(CultureInfo.CurrentCulture) : "<null>";
         }
 
         private DokanResult Trace(string method, string fileName, DokanFileInfo info, DokanResult result, params string[] parameters)
         {
             var extraParameters = parameters != null && parameters.Length > 0 ? ", " + string.Join(", ", parameters) : string.Empty;
 
-            Console.WriteLine($"{method}('{fileName}', {ToTrace(info)}{extraParameters}) -> {result}");
+#if TRACE
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}('{1}', {2}{3}) -> {4}",
+                method, fileName, ToTrace(info), extraParameters, result));
+#endif
 
             return result;
         }
 
-        private DokanResult Trace(string method, string fileName, DokanFileInfo info, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanResult result)
+        private DokanResult Trace(string method, string fileName, DokanFileInfo info,
+                                  FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes,
+                                  DokanResult result)
         {
-            Console.WriteLine($"{method}('{fileName}', {ToTrace(info)}, [{access}], [{share}], [{mode}], [{options}], [{attributes}]) -> {result}");
+#if TRACE
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}('{1}', {2}, [{3}], [{4}], [{5}], [{6}], [{7}]) -> {8}",
+                method, fileName, ToTrace(info), access, share, mode, options, attributes, result));
+#endif
 
             return result;
         }
@@ -92,30 +100,29 @@ namespace DokanNetMirror
                     if (pathExists)
                     {
                         if (readWriteAttributes || pathIsDirectory)
-                        //check if only wants to read attributes,security info or open directory
+                        // check if driver only wants to read attributes, security info, or open directory
                         {
                             info.IsDirectory = pathIsDirectory;
                             info.Context = new object();
-                            // Must set it to someting if you return DokanError.Success
+                            // must set it to someting if you return DokanError.Success
 
-                            return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.Success);
+                            return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.Success);
                         }
                     }
                     else
                     {
-                        return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
                     }
                     break;
 
                 case FileMode.CreateNew:
                     if (pathExists)
-                        return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.AlreadyExists);
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.AlreadyExists);
                     break;
 
                 case FileMode.Truncate:
                     if (!pathExists)
-                            return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
-
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
                     break;
 
                 default:
@@ -125,14 +132,13 @@ namespace DokanNetMirror
             try
             {
                 info.Context = new FileStream(path, mode, readAccess ? System.IO.FileAccess.Read : System.IO.FileAccess.ReadWrite, share, 4096, options);
-                streamIds.Add((Stream)info.Context, Interlocked.Increment(ref streamCount));
             }
-            catch (UnauthorizedAccessException) // Don't have access rights
+            catch (UnauthorizedAccessException) // don't have access rights
             {
-                return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.AccessDenied);
+                return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.AccessDenied);
             }
 
-            return Trace(nameof(CreateFile), fileName, info, access, share, mode, options, attributes, DokanResult.Success);
+            return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.Success);
         }
 
         public DokanResult OpenDirectory(string fileName, DokanFileInfo info)
@@ -140,43 +146,47 @@ namespace DokanNetMirror
             string path = GetPath(fileName);
             if (!Directory.Exists(path))
             {
-                return Trace(nameof(OpenDirectory), fileName, info, DokanResult.PathNotFound);
+                return Trace("OpenDirectory", fileName, info, DokanResult.PathNotFound);
             }
 
             try
             {
-                new DirectoryInfo(path).EnumerateFileSystemInfos().Any(); // You can't list directory
+                new DirectoryInfo(path).EnumerateFileSystemInfos().Any(); // you can't list the directory
             }
             catch (UnauthorizedAccessException)
             {
-                return Trace(nameof(OpenDirectory), fileName, info, DokanResult.AccessDenied);
+                return Trace("OpenDirectory", fileName, info, DokanResult.AccessDenied);
             }
-            return Trace(nameof(OpenDirectory), fileName, info, DokanResult.Success);
+            return Trace("OpenDirectory", fileName, info, DokanResult.Success);
         }
 
         public DokanResult CreateDirectory(string fileName, DokanFileInfo info)
         {
             if (Directory.Exists(GetPath(fileName)))
-                return Trace(nameof(CreateDirectory), fileName, info, DokanResult.AlreadyExists);
+                return Trace("CreateDirectory", fileName, info, DokanResult.AlreadyExists);
 
             try
             {
                 Directory.CreateDirectory(GetPath(fileName));
-                return Trace(nameof(CreateDirectory), fileName, info, DokanResult.Success);
+                return Trace("CreateDirectory", fileName, info, DokanResult.Success);
             }
             catch (UnauthorizedAccessException)
             {
-                return Trace(nameof(CreateDirectory), fileName, info, DokanResult.AccessDenied);
+                return Trace("CreateDirectory", fileName, info, DokanResult.AccessDenied);
             }
         }
 
         public DokanResult Cleanup(string fileName, DokanFileInfo info)
         {
-            Trace(nameof(Cleanup) + "(in)", fileName, info, DokanResult.Undefined);
+#if TRACE
+            if (info.Context != null)
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}('{1}', {2} - entering",
+                    "Cleanup", fileName, ToTrace(info)));
+#endif
+
             if (info.Context != null && info.Context is FileStream)
             {
                 (info.Context as FileStream).Dispose();
-                streamIds.Remove((Stream)info.Context);
             }
             info.Context = null;
 
@@ -191,26 +201,29 @@ namespace DokanNetMirror
                     File.Delete(GetPath(fileName));
                 }
             }
-            return Trace(nameof(Cleanup), fileName, info, DokanResult.Success);
+            return Trace("Cleanup", fileName, info, DokanResult.Success);
         }
 
         public DokanResult CloseFile(string fileName, DokanFileInfo info)
         {
-            Trace(nameof(CloseFile) + "(in)", fileName, info, DokanResult.Undefined);
+#if TRACE
+            if (info.Context != null)
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}('{1}', {2} - entering",
+                    "CloseFile", fileName, ToTrace(info)));
+#endif
+
             if (info.Context != null && info.Context is FileStream)
             {
                 (info.Context as FileStream).Dispose();
-                streamIds.Remove((Stream)info.Context);
             }
             info.Context = null;
-            return Trace(nameof(CloseFile), fileName, info, DokanResult.Success); // could recreate cleanup code hear but this is not called sometimes
+            return Trace("CloseFile", fileName, info, DokanResult.Success); // could recreate cleanup code here but this is not called sometimes
         }
 
         public DokanResult ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
         {
             if (info.Context == null) // memory mapped read
             {
-                Trace(nameof(ReadFile) + "(no Context)", fileName, info, DokanResult.Undefined, offset.ToString(CultureInfo.InvariantCulture));
                 using (var stream = new FileStream(GetPath(fileName), FileMode.Open, System.IO.FileAccess.Read))
                 {
                     stream.Position = offset;
@@ -223,14 +236,13 @@ namespace DokanNetMirror
                 stream.Position = offset;
                 bytesRead = stream.Read(buffer, 0, buffer.Length);
             }
-            return Trace(nameof(ReadFile), fileName, info, DokanResult.Success, $"out {bytesRead}", offset.ToString(CultureInfo.InvariantCulture));
+            return Trace("ReadFile", fileName, info, DokanResult.Success, "out " + bytesRead.ToString(), offset.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
         {
             if (info.Context == null)
             {
-                Trace(nameof(WriteFile) + "(no Context)", fileName, info, DokanResult.Undefined, offset.ToString(CultureInfo.InvariantCulture));
                 using (var stream = new FileStream(GetPath(fileName), FileMode.Open, System.IO.FileAccess.Write))
                 {
                     stream.Position = offset;
@@ -244,7 +256,7 @@ namespace DokanNetMirror
                 stream.Write(buffer, 0, buffer.Length);
                 bytesWritten = buffer.Length;
             }
-            return Trace(nameof(WriteFile), fileName, info, DokanResult.Success, $"out {bytesWritten}", offset.ToString(CultureInfo.InvariantCulture));
+            return Trace("WriteFile", fileName, info, DokanResult.Success, "out " + bytesWritten.ToString(), offset.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult FlushFileBuffers(string fileName, DokanFileInfo info)
@@ -252,17 +264,17 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Flush();
-                return Trace(nameof(FlushFileBuffers), fileName, info, DokanResult.Success);
+                return Trace("FlushFileBuffers", fileName, info, DokanResult.Success);
             }
             catch (IOException)
             {
-                return Trace(nameof(FlushFileBuffers), fileName, info, DokanResult.DiskFull);
+                return Trace("FlushFileBuffers", fileName, info, DokanResult.DiskFull);
             }
         }
 
         public DokanResult GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
         {
-            // may be called with info.Context=null , but usually it isn't
+            // may be called with info.Context == null, but usually it isn't
             string path = GetPath(fileName);
             FileSystemInfo finfo = new FileInfo(path);
             if (!finfo.Exists)
@@ -277,7 +289,7 @@ namespace DokanNetMirror
                 LastWriteTime = finfo.LastWriteTime,
                 Length = (finfo is FileInfo) ? ((FileInfo)finfo).Length : 0,
             };
-            return Trace(nameof(GetFileInformation), fileName, info, DokanResult.Success);
+            return Trace("GetFileInformation", fileName, info, DokanResult.Success);
         }
 
         public DokanResult FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
@@ -294,7 +306,7 @@ namespace DokanNetMirror
                     FileName = finfo.Name
                 }).ToArray();
 
-            return Trace(nameof(FindFiles), fileName, info, DokanResult.Success);
+            return Trace("FindFiles", fileName, info, DokanResult.Success);
         }
 
         public DokanResult SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
@@ -302,19 +314,19 @@ namespace DokanNetMirror
             try
             {
                 File.SetAttributes(GetPath(fileName), attributes);
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.Success, attributes.ToString());
+                return Trace("SetFileAttributes", fileName, info, DokanResult.Success, attributes.ToString());
             }
             catch (UnauthorizedAccessException)
             {
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.AccessDenied, attributes.ToString());
+                return Trace("SetFileAttributes", fileName, info, DokanResult.AccessDenied, attributes.ToString());
             }
             catch (FileNotFoundException)
             {
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.FileNotFound, attributes.ToString());
+                return Trace("SetFileAttributes", fileName, info, DokanResult.FileNotFound, attributes.ToString());
             }
             catch (DirectoryNotFoundException)
             {
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.PathNotFound, attributes.ToString());
+                return Trace("SetFileAttributes", fileName, info, DokanResult.PathNotFound, attributes.ToString());
             }
         }
 
@@ -332,28 +344,28 @@ namespace DokanNetMirror
                 if (lastWriteTime.HasValue)
                     File.SetLastWriteTime(path, lastWriteTime.Value);
 
-                return Trace(nameof(SetFileTime), fileName, info, DokanResult.Success, creationTime.ToString(), lastAccessTime.ToString(), lastWriteTime.ToString());
+                return Trace("SetFileTime", fileName, info, DokanResult.Success, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
             catch (UnauthorizedAccessException)
             {
-                return Trace(nameof(SetFileTime), fileName, info, DokanResult.AccessDenied, creationTime.ToString(), lastAccessTime.ToString(), lastWriteTime.ToString());
+                return Trace("SetFileTime", fileName, info, DokanResult.AccessDenied, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
             catch (FileNotFoundException)
             {
-                return Trace(nameof(SetFileTime), fileName, info, DokanResult.FileNotFound, creationTime.ToString(), lastAccessTime.ToString(), lastWriteTime.ToString());
+                return Trace("SetFileTime", fileName, info, DokanResult.FileNotFound, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
         }
 
         public DokanResult DeleteFile(string fileName, DokanFileInfo info)
         {
-            return Trace(nameof(DeleteFile), fileName, info, File.Exists(GetPath(fileName)) ? DokanResult.Success : DokanResult.FileNotFound);
-            // we just check here if we could delete file the true deletion is in Cleanup
+            return Trace("DeleteFile", fileName, info, File.Exists(GetPath(fileName)) ? DokanResult.Success : DokanResult.FileNotFound);
+            // we just check here if we could delete the file - the true deletion is in Cleanup
         }
 
         public DokanResult DeleteDirectory(string fileName, DokanFileInfo info)
         {
-            return Trace(nameof(DeleteDirectory), fileName, info, Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any() ? DokanResult.DirNotEmpty : DokanResult.Success);
-            // if dir is not empty could not delete
+            return Trace("DeleteDirectory", fileName, info, Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any() ? DokanResult.DirNotEmpty : DokanResult.Success);
+            // if dir is not empty it can't be deleted
         }
 
         public DokanResult MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
@@ -362,25 +374,21 @@ namespace DokanNetMirror
             string newpath = GetPath(newName);
             if (!File.Exists(newpath))
             {
-                if (info.Context != null)
-                    streamIds.Remove((Stream)info.Context);
                 info.Context = null;
 
                 File.Move(oldpath, newpath);
-                return Trace(nameof(MoveFile), oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
+                return Trace("MoveFile", oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
             }
             else if (replace)
             {
-                if (info.Context != null)
-                    streamIds.Remove((Stream)info.Context);
                 info.Context = null;
 
                 if (!info.IsDirectory)
                     File.Delete(newpath);
                 File.Move(oldpath, newpath);
-                return Trace(nameof(MoveFile), oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
+                return Trace("MoveFile", oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
             }
-            return Trace(nameof(MoveFile), oldName, info, DokanResult.FileExists, newName, replace.ToString(CultureInfo.InvariantCulture));
+            return Trace("MoveFile", oldName, info, DokanResult.FileExists, newName, replace.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult SetEndOfFile(string fileName, long length, DokanFileInfo info)
@@ -388,11 +396,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).SetLength(length);
-                return Trace(nameof(SetEndOfFile), fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
+                return Trace("SetEndOfFile", fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return Trace(nameof(SetEndOfFile), fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
+                return Trace("SetEndOfFile", fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -401,11 +409,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).SetLength(length);
-                return Trace(nameof(SetAllocationSize), fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
+                return Trace("SetAllocationSize", fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return Trace(nameof(SetAllocationSize), fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
+                return Trace("SetAllocationSize", fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -414,11 +422,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Lock(offset, length);
-                return Trace(nameof(LockFile), fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
+                return Trace("LockFile", fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return Trace(nameof(LockFile), fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
+                return Trace("LockFile", fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -427,22 +435,22 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Unlock(offset, length);
-                return Trace(nameof(UnlockFile), fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
+                return Trace("UnlockFile", fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return Trace(nameof(UnlockFile), fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
+                return Trace("UnlockFile", fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
         public DokanResult GetDiskFreeSpace(out long free, out long total, out long used, DokanFileInfo info)
         {
-            var dinfo = DriveInfo.GetDrives().Where(di => di.RootDirectory.Name == Path.GetPathRoot(_path + "\\")).Single();
+            var dinfo = DriveInfo.GetDrives().Where(di => di.RootDirectory.Name == Path.GetPathRoot(path + "\\")).Single();
 
             used = dinfo.AvailableFreeSpace;
             total = dinfo.TotalSize;
             free = dinfo.TotalFreeSpace;
-            return Trace(nameof(GetDiskFreeSpace), null, info, DokanResult.Success, $"out {free}", $"out {total}", $"out {used}");
+            return Trace("GetDiskFreeSpace", null, info, DokanResult.Success, "out " + free.ToString(), "out " + total.ToString(), "out " + used.ToString());
         }
 
         public DokanResult GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features,
@@ -455,7 +463,7 @@ namespace DokanNetMirror
                        FileSystemFeatures.PersistentAcls | FileSystemFeatures.SupportsRemoteStorage |
                        FileSystemFeatures.UnicodeOnDisk;
 
-            return Trace(nameof(GetVolumeInformation), null, info, DokanResult.Success, $"out {volumeLabel}", $"out {features}", $"out {fileSystemName}");
+            return Trace("GetVolumeInformation", null, info, DokanResult.Success, "out " + volumeLabel, "out " + features.ToString(), "out " + fileSystemName);
         }
 
         public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
@@ -465,12 +473,12 @@ namespace DokanNetMirror
                 security = info.IsDirectory
                                ? (FileSystemSecurity)Directory.GetAccessControl(GetPath(fileName))
                                : File.GetAccessControl(GetPath(fileName));
-                return Trace(nameof(GetFileSecurity), fileName, info, DokanResult.Success, $"{sections}");
+                return Trace("GetFileSecurity", fileName, info, DokanResult.Success, sections.ToString());
             }
             catch (UnauthorizedAccessException)
             {
                 security = null;
-                return Trace(nameof(GetFileSecurity), fileName, info, DokanResult.AccessDenied, $"{sections}");
+                return Trace("GetFileSecurity", fileName, info, DokanResult.AccessDenied, sections.ToString());
             }
         }
 
@@ -486,24 +494,24 @@ namespace DokanNetMirror
                 {
                     File.SetAccessControl(GetPath(fileName), (FileSecurity)security);
                 }
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.Success, sections.ToString());
+                return Trace("SetFileSecurity", fileName, info, DokanResult.Success, sections.ToString());
             }
             catch (UnauthorizedAccessException)
             {
-                return Trace(nameof(SetFileAttributes), fileName, info, DokanResult.AccessDenied, sections.ToString());
+                return Trace("SetFileSecurity", fileName, info, DokanResult.AccessDenied, sections.ToString());
             }
         }
 
         public DokanResult Unmount(DokanFileInfo info)
         {
-            return Trace(nameof(Unmount), null, info, DokanResult.Success);
+            return Trace("Unmount", null, info, DokanResult.Success);
         }
 
         public DokanResult EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize, DokanFileInfo info)
         {
             streamName = String.Empty;
             streamSize = 0;
-            return Trace(nameof(EnumerateNamedStreams), fileName, info, DokanResult.Error, enumContext.ToString(), $"out {streamName}", $"out {streamSize}");
+            return Trace("EnumerateNamedStreams", fileName, info, DokanResult.Error, enumContext.ToString(), "out " + streamName, "out " + streamSize.ToString());
         }
 
         #endregion Implementation of IDokanOperations


### PR DESCRIPTION
DokanOperationsProxy now returns a DokanResult value != `DokanResult.Success`
Tracing reworked in DokanNet project
Tracing added to Mirror sample